### PR TITLE
Coverage times now show in proper time zone

### DIFF
--- a/admin/time-utilities.php
+++ b/admin/time-utilities.php
@@ -62,7 +62,7 @@ class DT_Time_Utilities {
 
                 $data[$start]['hours'][] = [
                     'key' => $time_begin,
-                    'formatted' => gmdate( 'H:i', $time_begin ),
+                    'formatted' => gmdate( 'H:i', $time_begin - $start ),
                     'subscribers' => $current_times_list[$time_begin] ?? 0,
                 ];
 


### PR DESCRIPTION
Before this fix, the coverage chart would show the times in UTC instead of the selected time zone for the campaign.

This means that if you selected a UTC+3 time zone, the coverage chart would start at 03:00 instead of 00:00

Now it displays the correct time.
<img width="423" alt="Screen Shot 2022-04-04 at 18 09 35" src="https://user-images.githubusercontent.com/36511666/161632696-5344011a-6a80-4142-b65f-4a6e0fa55e8a.png">