### PR TITLE
Refactor/enqueue scripts correctly in footer

### DIFF
--- a/porches/generic/site/footer.php
+++ b/porches/generic/site/footer.php
@@ -50,28 +50,3 @@
         <div class="double-bounce2"></div>
     </div>
 </div>
-
-<!-- jQuery first, then Tether, then Bootstrap JS. -->
-<!-- TODO: put these into enqueue scripts properly -->
-<?php // phpcs:disable ?>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/jquery-min.js"></script>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/tether.min.js"></script>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/bootstrap.min.js"></script>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/classie.js"></script>
-<!--<script src="--><?php //echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?><!--js/mixitup.min.js"></script>-->
-<!--<script src="--><?php //echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?><!--js/nivo-lightbox.js"></script>-->
-<!--<script src="--><?php //echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?><!--js/owl.carousel.min.js"></script>-->
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/jquery.stellar.min.js"></script>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/jquery.nav.js"></script>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/smooth-scroll.js"></script>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/smooth-on-scroll.js"></script>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/wow.js"></script>
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/menu.js"></script>
-<!--<script src="--><?php //echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?><!--js/jquery.vide.js"></script>-->
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/jquery.counterup.min.js"></script>
-<!--<script src="--><?php //echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?><!--js/jquery.magnific-popup.min.js"></script>-->
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/waypoints.min.js"></script>
-<!--<script src="--><?php //echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?><!--js/form-validator.min.js"></script>-->
-<!--<script src="--><?php //echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?><!--js/contact-form-script.js"></script>-->
-<script src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>js/main.js?ver=<?php echo esc_attr( filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . 'js/main.js' ) ) ?>"></script>
-<?php // phpcs:enable ?>

--- a/porches/generic/site/home.php
+++ b/porches/generic/site/home.php
@@ -59,18 +59,16 @@ class P4_Ramadan_Porch_Home_5 extends DT_Magic_Url_Base
         }
     }
     public function wp_enqueue_scripts(){
-        $lang = dt_campaign_get_current_lang();
-        $translations = dt_ramadan_list_languages();
-        if ( isset( $translations[$lang]["dir"] ) && $translations[$lang]['dir'] === 'rtl' ){
-            wp_enqueue_style( 'porch-style-css', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'css/rtl.css', array(), filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . 'css/rtl.css' ), 'all' );
-        }
+        require_once( 'landing-enqueue.php' );
+        P4_Ramadan_Porch_Landing_Enqueue::load_scripts();
     }
+
     public function dt_custom_dir_attr( $lang ){
         return ramadan_custom_dir_attr( $lang );
     }
 
     public function dt_magic_url_base_allowed_js( $allowed_js ) {
-        return [ 'jquery', 'lodash', 'lodash-core' ];
+        return array_merge( [ 'jquery', 'lodash', 'lodash-core' ], P4_Ramadan_Porch_Landing_Enqueue::load_allowed_scripts() );
     }
 
     public function dt_magic_url_base_allowed_css( $allowed_css ) {

--- a/porches/generic/site/landing-enqueue.php
+++ b/porches/generic/site/landing-enqueue.php
@@ -10,13 +10,40 @@ class P4_Ramadan_Porch_Landing_Enqueue
         if ( isset( $translations[$lang]["dir"] ) && $translations[$lang]['dir'] === 'rtl' ){
             wp_enqueue_style( 'porch-style-css', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'css/rtl.css', array(), filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . 'css/rtl.css' ), 'all' );
         }
+
+        wp_deregister_script( 'jquery' );
+        wp_enqueue_script( 'my-jquery', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/jquery-min.js", [], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/jquery-min.js" ), true );
+        wp_enqueue_script( 'tether', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/tether.min.js", [ 'my-jquery' ], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/tether.min.js" ), true );
+        wp_enqueue_script( 'bootstrap', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/bootstrap.min.js", [ 'my-jquery' ], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/bootstrap.min.js" ), true );
+        wp_enqueue_script( 'classie', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/classie.js", [ 'my-jquery' ], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/classie.js" ), true );
+        wp_enqueue_script( 'jquery.stellar', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/jquery.stellar.min.js", [ 'my-jquery' ], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/jquery.stellar.min.js" ), true );
+        wp_enqueue_script( 'jquery.nav', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/jquery.nav.js", [ 'my-jquery' ], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/jquery.nav.js" ), true );
+        wp_enqueue_script( 'smooth-scroll', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/smooth-scroll.js", [], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/smooth-scroll.js" ), true );
+        wp_enqueue_script( 'smooth-on-scroll', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/smooth-on-scroll.js", [], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/smooth-on-scroll.js" ), true );
+        wp_enqueue_script( 'wow', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/wow.js", [], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/wow.js" ), true );
+        wp_enqueue_script( 'menu', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/menu.js", [], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/menu.js" ), true );
+        wp_enqueue_script( 'jquery.counterup', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/jquery.counterup.min.js", [ 'my-jquery' ], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/jquery.counterup.min.js" ), true );
+        wp_enqueue_script( 'waypoints', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/waypoints.min.js", [], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/waypoints.min.js" ), true );
+        wp_enqueue_script( 'main', trailingslashit( plugin_dir_url( __FILE__ ) ) . "js/main.js", [], filemtime( trailingslashit( plugin_dir_path( __FILE__ ) ) . "js/main.js" ), true );
     }
 
     public static function load_allowed_scripts() {
         return [
-            'jquery',
+            'my-jquery',
             'jquery-ui',
-            'porch-site-js'
+            'porch-site-js',
+            'tether',
+            'bootstrap',
+            'classie',
+            'jquery.stellar',
+            'jquery.nav',
+            'smooth-scroll',
+            'smooth-on-scroll',
+            'wow',
+            'menu',
+            'jquery.counterup',
+            'waypoints',
+            'main',
         ];
     }
 


### PR DESCRIPTION
resolves #44

@corsacca ready to go

In changing the scripts from the footer to the enqueue scripts thing, after getting through the magic link gauntlet, the last issue to overcome was the WP auto enqueued version of jquery being on the 'jquery' handle...

For now I've attempted to deregister wp's jquery (which has failed, not sure why) and used a custom handle name for the jquery that this porch actually wants to be using ( and falls over if it doesn't have it :( )