### PR TITLE
Feat/signup tweaks

### DIFF
--- a/assets/js/mailchimp.js
+++ b/assets/js/mailchimp.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var displayMailChimpStatus = function (data) {
+  console.log(data)
+}
+
+/* help from and kudos to https://css-tricks.com/form-validation-part-4-validating-mailchimp-subscribe-form/ */
+function submitMailChimpSubscribe(form) {
+  let url = form.action;
+  url = url.replace('/post', '/post-json')
+
+  const serialisedFormData = new URLSearchParams( new FormData( form ) )
+
+  url += `&${serialisedFormData.toString()}&c=displayMailChimpStatus`
+
+  const script = window.document.createElement( 'script' );
+  script.src = url;
+
+  const ref = window.document.getElementsByTagName( 'script' )[ 0 ];
+  ref.parentNode.insertBefore( script, ref );
+
+  script.onload = function () {
+      this.remove();
+  };
+}

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "wp-coding-standards/wpcs": "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,5 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "wp-coding-standards/wpcs": "*"
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
     }
 }

--- a/magic-links/24hour/24hour.js
+++ b/magic-links/24hour/24hour.js
@@ -17,6 +17,10 @@ let escapeObject = (obj) => {
   }))
 }
 
+var displayMailChimpStatus = function (data) {
+  console.log(data)
+}
+
 jQuery(document).ready(function($) {
   let jsObject = window.campaign_objects
 
@@ -359,9 +363,13 @@ jQuery(document).ready(function($) {
       draw_modal_calendar()
     })
 
-
     //submit form
-    $('#cp-submit-form').on('click', function (){
+    $('#cp-submit-form').on('click', async function () {
+      if ( document.querySelector('#receive_pray4movement_news').checked ) {
+        const form = document.getElementById('mc-embedded-subscribe-form')
+        submitMailChimpSubscribe(form)
+      }
+
       let submit_spinner = $('#cp-submit-form-spinner-later');
       let submit_button = jQuery('#cp-submit-form')
       submit_button.prop('disabled', true)

--- a/magic-links/ongoing/ongoing.js
+++ b/magic-links/ongoing/ongoing.js
@@ -184,6 +184,10 @@ jQuery(document).ready(async function ($) {
 
     //submit form
     $('#cp-submit-form').on('click', function (){
+      if ( document.querySelector('#receive_pray4movement_news').checked ) {
+        const form = document.getElementById('mc-embedded-subscribe-form')
+        submitMailChimpSubscribe(form)
+      }
       let submit_spinner = $('#cp-submit-form-spinner');
       let submit_button = jQuery('#cp-submit-form')
       submit_button.prop('disabled', true)

--- a/parts/components.php
+++ b/parts/components.php
@@ -1,0 +1,65 @@
+<?php
+
+function dt_campaign_sign_up_form() {
+    ?>
+            <h2><?php esc_html_e( 'Confirm', 'disciple-tools-prayer-campaigns' ); ?></h2>
+            <br>
+            <!-- @todo summary -->
+            <!--            <p>-->
+            <!--                You are signing up to praying for-->
+            <!--                <span id="time-duration-confirmation" style="font-weight: bold" ></span>-->
+            <!--                on each selected day at <span id="time-confirmation" style="font-weight: bold"></span>-->
+            <!--                in <span class="timezone-current"></span> timezone.-->
+            <!--            </p>-->
+            <form
+                action="https://training.us14.list-manage.com/subscribe/post?u=d9ad41b66865008d664ac28bf&amp;id=4df6e5ea4e"
+                method="post"
+                id="mc-embedded-subscribe-form"
+                name="mc-embedded-subscribe-form"
+                class="validate"
+                target="_blank"
+                novalidate
+            >
+                <div>
+                    <span id="name-error" class="form-error">
+                        <?php echo esc_html( "Your name is required" ); ?>
+                    </span>
+                    <label for="name"><?php esc_html_e( 'Name', 'disciple-tools-prayer-campaigns' ); ?><br>
+                        <input class="cp-input" type="text" name="name" id="name" placeholder="<?php esc_html_e( 'Name', 'disciple-tools-prayer-campaigns' ); ?>" required/>
+                    </label>
+                </div>
+                <div>
+                    <span id="email-error" class="form-error">
+                        <?php esc_html_e( "Your email is required.", 'disciple-tools-prayer-campaigns' ); ?>
+                    </span>
+                    <label for="email"><?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?><br>
+                        <input class="cp-input" type="email" name="email" id="email" placeholder="<?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?>" />
+                        <input class="cp-input" type="email" name="EMAIL" id="e2" placeholder="<?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?>" required />
+                    </label>
+                    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_d9ad41b66865008d664ac28bf_4df6e5ea4e" tabindex="-1" value=""></div>
+                    <div id="mce-responses" class="clear">
+                        <div class="response" id="mce-error-response" style="display:none"></div>
+                    </div>
+                </div>
+                <div>
+                    <p>
+                        <label for="receive_prayer_time_notifications">
+                            <input type="checkbox" id="receive_prayer_time_notifications" name="receive_prayer_time_notifications" checked />
+                            <?php esc_html_e( 'Receive Prayer Time Notifications (email verification needed).', 'disciple-tools-prayer-campaigns' ); ?>
+                        </label>
+                    </p>
+                    <p>
+                        <label for="receive_pray4movement_news">
+                            <input type="checkbox" id="receive_pray4movement_news" name="receive_pray4movement_news" checked />
+                            <?php esc_html_e( 'Recieve Pray4Movement Newsletter (email verification needed).', 'disciple-tools-prayer-campaigns' ); ?>
+                        </label>
+                    </p>
+                    <div>
+                        <button type="submit" class="button loader" id="cp-submit-form" name="subscribe" value="Subscribe">
+                            <?php esc_html_e( 'Submit Your Prayer Commitment', 'disciple-tools-prayer-campaigns' ); ?> <img id="cp-submit-form-spinner" style="display: none" src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>../spinner.svg" width="22px" alt="spinner "/></button>
+                    </div>
+                </div>
+            </form>
+    <?php
+}

--- a/parts/components.php
+++ b/parts/components.php
@@ -36,6 +36,7 @@ function dt_campaign_sign_up_form() {
                         <input class="cp-input" type="email" name="email" id="email" placeholder="<?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?>" />
                         <input class="cp-input" type="email" name="EMAIL" id="e2" placeholder="<?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?>" required />
                     </label>
+                    <div hidden="true"><input type="hidden" name="tags" value="7315913"></div>
                     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
                     <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_d9ad41b66865008d664ac28bf_4df6e5ea4e" tabindex="-1" value=""></div>
                     <div id="mce-responses" class="clear">

--- a/shortcodes/24hour.php
+++ b/shortcodes/24hour.php
@@ -5,6 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 function dt_24hour_campaign_register_scripts( $atts ){
 
+    require_once( trailingslashit( __DIR__ ) . '../parts/components.php' );
+
     wp_register_script( 'luxon', 'https://cdn.jsdelivr.net/npm/luxon@2.3.1/build/global/luxon.min.js', false, "2.3.1", true );
     //campaigns core js
     if ( !wp_script_is( 'dt_campaign_core', "registered" ) ){
@@ -20,6 +22,7 @@ function dt_24hour_campaign_register_scripts( $atts ){
 
     //24 hour campaign js
     if ( !wp_script_is( 'dt_campaign' ) ){
+        wp_enqueue_script( 'dt_mailchimp', trailingslashit( plugin_dir_url( __DIR__ ) ) . 'assets/js/mailchimp.js', [], filemtime( plugin_dir_path( __DIR__ ) . 'assets/js/mailchimp.js' ), true );
         wp_enqueue_script( 'dt_campaign', trailingslashit( plugin_dir_url( __DIR__ ) ) . 'magic-links/24hour/24hour.js', [ 'luxon', 'jquery', 'dt_campaign_core' ], filemtime( plugin_dir_path( __DIR__ ) . 'magic-links/24hour/24hour.js' ), true );
         wp_localize_script(
             'dt_campaign', 'campaign_objects', [
@@ -214,45 +217,8 @@ function dt_24hour_campaign_body( $color = "", $section = "" ){
                 <img src="<?php echo esc_html( plugin_dir_url( __DIR__ ) . 'assets/back_icon.svg' ) ?>"/>
                 <span aria-hidden="true"> <?php esc_html_e( 'Back', 'disciple-tools-prayer-campaigns' ); ?> </span>
             </button>
-            <h2><?php esc_html_e( 'Confirm', 'disciple-tools-prayer-campaigns' ); ?></h2>
-            <br>
-            <!-- @todo summary -->
-            <!--            <p>-->
-            <!--                You are signing up to praying for-->
-            <!--                <span id="time-duration-confirmation" style="font-weight: bold" ></span>-->
-            <!--                on each selected day at <span id="time-confirmation" style="font-weight: bold"></span>-->
-            <!--                in <span class="timezone-current"></span> timezone.-->
-            <!--            </p>-->
 
-            <div>
-                <span id="name-error" class="form-error">
-                    <?php echo esc_html( "Your name is required" ); ?>
-                </span>
-                <label for="name"><?php esc_html_e( 'Name', 'disciple-tools-prayer-campaigns' ); ?><br>
-                    <input class="cp-input" type="text" name="name" id="name" placeholder="<?php esc_html_e( 'Name', 'disciple-tools-prayer-campaigns' ); ?>" required/>
-                </label>
-            </div>
-            <div>
-                <span id="email-error" class="form-error">
-                    <?php esc_html_e( "Your email is required.", 'disciple-tools-prayer-campaigns' ); ?>
-                </span>
-                <label for="email"><?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?><br>
-                    <input class="cp-input" type="email" name="email" id="email" placeholder="<?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?>" />
-                    <input class="cp-input" type="email" name="e2" id="e2" placeholder="<?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?>" required />
-                </label>
-            </div>
-            <div>
-                <p>
-                    <label for="receive_prayer_time_notifications">
-                        <input type="checkbox" id="receive_prayer_time_notifications" name="receive_prayer_time_notifications" checked />
-                        <?php esc_html_e( 'Receive Prayer Time Notifications (email verification needed).', 'disciple-tools-prayer-campaigns' ); ?>
-                    </label>
-                </p>
-                <div>
-                    <button class="button loader" id="cp-submit-form">
-                        <?php esc_html_e( 'Submit Your Prayer Commitment', 'disciple-tools-prayer-campaigns' ); ?> <img id="cp-submit-form-spinner" style="display: none" src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>../spinner.svg" width="22px" alt="spinner "/></button>
-                </div>
-            </div>
+            <?php dt_campaign_sign_up_form() ?>
 
             <div class="success-confirmation-section">
                 <div class="cell center">

--- a/shortcodes/ongoing.php
+++ b/shortcodes/ongoing.php
@@ -44,6 +44,8 @@ class DT_Ongoing_Shortcode {
 
     private function dt_24hour_campaign_register_scripts( $atts ){
 
+        require_once( trailingslashit( __DIR__ ) . '../parts/components.php' );
+
         wp_register_script( 'luxon', 'https://cdn.jsdelivr.net/npm/luxon@2.3.1/build/global/luxon.min.js', false, "2.3.1", true );
         //campaigns core js
         if ( !wp_script_is( 'dt_campaign_core', "registered" ) ){
@@ -59,6 +61,7 @@ class DT_Ongoing_Shortcode {
 
         //24 hour campaign js
         if ( !wp_script_is( 'dt_campaign' ) ){
+            wp_enqueue_script( 'dt_mailchimp', trailingslashit( plugin_dir_url( __DIR__ ) ) . 'assets/js/mailchimp.js', [], filemtime( plugin_dir_path( __DIR__ ) . 'assets/js/mailchimp.js' ), true );
             wp_enqueue_script( 'dt_campaign', trailingslashit( plugin_dir_url( __DIR__ ) ) . $this->js_file, [ 'luxon', 'jquery', 'dt_campaign_core' ], filemtime( plugin_dir_path( __DIR__ ) . $this->js_file ), true );
             wp_localize_script(
                 'dt_campaign', 'campaign_objects', [
@@ -250,38 +253,8 @@ function dt_ongoing_campaign_signup( $atts ){
                     <img src="<?php echo esc_html( plugin_dir_url( __DIR__ ) . 'assets/back_icon.svg' ) ?>"/>
                     <span aria-hidden="true"> <?php esc_html_e( 'Back', 'disciple-tools-prayer-campaigns' ); ?> </span>
                 </button>
-                <h2><?php esc_html_e( 'Confirm', 'disciple-tools-prayer-campaigns' ); ?></h2>
-                <br>
 
-                <div>
-                <span id="name-error" class="form-error">
-                    <?php echo esc_html( "Your name is required" ); ?>
-                </span>
-                    <label for="name"><?php esc_html_e( 'Name', 'disciple-tools-prayer-campaigns' ); ?><br>
-                        <input class="cp-input" type="text" name="name" id="name" placeholder="<?php esc_html_e( 'Name', 'disciple-tools-prayer-campaigns' ); ?>" required/>
-                    </label>
-                </div>
-                <div>
-                <span id="email-error" class="form-error">
-                    <?php esc_html_e( "Your email is required.", 'disciple-tools-prayer-campaigns' ); ?>
-                </span>
-                    <label for="email"><?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?><br>
-                        <input class="cp-input" type="email" name="email" id="email" placeholder="<?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?>" />
-                        <input class="cp-input" type="email" name="e2" id="e2" placeholder="<?php esc_html_e( 'Email', 'disciple-tools-prayer-campaigns' ); ?>" required />
-                    </label>
-                </div>
-                <div>
-                    <p>
-                        <label for="receive_prayer_time_notifications">
-                            <input type="checkbox" id="receive_prayer_time_notifications" name="receive_prayer_time_notifications" checked />
-                            <?php esc_html_e( 'Receive Prayer Time Notifications (email verification needed).', 'disciple-tools-prayer-campaigns' ); ?>
-                        </label>
-                    </p>
-                    <div>
-                        <button class="button loader" id="cp-submit-form">
-                            <?php esc_html_e( 'Submit Your Prayer Commitment', 'disciple-tools-prayer-campaigns' ); ?> <img id="cp-submit-form-spinner" style="display: none" src="<?php echo esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) ) ?>../spinner.svg" width="22px" alt="spinner "/></button>
-                    </div>
-                </div>
+                <?php dt_campaign_sign_up_form() ?>
 
                 <div class="success-confirmation-section">
                     <div class="cell center">


### PR DESCRIPTION
resolves #41 

I have moved the signup form to a function in `parts/components.php`  for now as I wanted it to be reusable between different campaign types.

Not sure that's the best naming or place, but that can easily be changed.

The mailchimp subscription is happening in a totally custom way which will save space as the mailchimp validation script is big as it contains jQuery source.

[https://css-tricks.com/form-validation-part-4-validating-mailchimp-subscribe-form/](https://css-tricks.com/form-validation-part-4-validating-mailchimp-subscribe-form/) was reaaallly helpful in terms of how to submit the form correctly