### PR TITLE
ci: fix new composer issue with phpcodesniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "wp-coding-standards/wpcs": "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the issues being had in travis builds such as [this one](https://app.travis-ci.com/github/DiscipleTools/disciple-tools-prayer-campaigns/jobs/575354913)

where because the newer travis builds are all using the most up to date version of composer, we are suddenly having an issue.

If you look up in the logs of this build to where the composer install runs, you will see some warnings about phpcodesniffer needing to be trusted. This is with composer 2.3.7 upgrading to 2.3.8

This was then causing the sniffs to fail later.

This PR fixes this by doing what the comments there tell you to do