### PR TITLE
fix: translation buttons in other section

### DIFF
--- a/classes/dt-porch-admin-tab-base.php
+++ b/classes/dt-porch-admin-tab-base.php
@@ -102,13 +102,19 @@ class DT_Porch_Admin_Tab_Base {
         ?>
         <?php foreach ( DT_Porch_Settings::sections( $this->tab ) as $section ): ?>
 
+            <?php if ( empty( $section ) ) {
+                $section_name = "Other";
+            } else {
+                $section_name = $section;
+            } ?>
+
             <form method="post" class="metabox-table" name="<?php echo esc_html( $section ) ?>">
                 <?php wp_nonce_field( 'generic_porch_settings', 'generic_porch_settings_nonce' ) ?>
                 <!-- Box -->
                 <table class="widefat striped">
                     <thead>
                     <tr>
-                        <th style="width:20%"><?php echo esc_html( $section === '' ? 'Other' : $section ) ?> Content</th>
+                        <th style="width:20%"><?php echo esc_html( $section_name ) ?> Content</th>
                         <th style="width:50%"></th>
                         <th style="width:30%"></th>
                     </tr>
@@ -138,7 +144,7 @@ class DT_Porch_Admin_Tab_Base {
                                     </td>
                                     <td style="vertical-align: middle;">
                                         <?php if ( isset( $field['translations'] ) ){
-                                            self::translation_cell( $langs, $key, $field, $section );
+                                            self::translation_cell( $langs, $key, $field, $section_name );
                                         } ?>
                                     </td>
                                 </tr>

--- a/classes/dt-porch-admin-tab-base.php
+++ b/classes/dt-porch-admin-tab-base.php
@@ -103,7 +103,7 @@ class DT_Porch_Admin_Tab_Base {
         <?php foreach ( DT_Porch_Settings::sections( $this->tab ) as $section ): ?>
 
             <?php if ( empty( $section ) ) {
-                $section_name = "Other";
+                $section_name = 'Other';
             } else {
                 $section_name = $section;
             } ?>


### PR DESCRIPTION
fix: give 'other' section the name 'Other' to link translations to other form

resolves #107 
