### PR TITLE
- Replace Google Analytics textarea with text field.

### DIFF
--- a/admin/class-migration-engine.php
+++ b/admin/class-migration-engine.php
@@ -16,7 +16,7 @@ class DT_Prayer_Campaigns_Migration_Engine
      * Current Migration number for the mapping system
      * @var int
      */
-    public static $migration_number = 5;
+    public static $migration_number = 6;
 
     protected static $migrations = null;
 

--- a/admin/migrations/0006-change-google-analytics-field-type.php
+++ b/admin/migrations/0006-change-google-analytics-field-type.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
+/**
+ * Class DT_Prayer_Campaign_Migration_0006
+ */
+class DT_Prayer_Campaign_Migration_0006 extends DT_Prayer_Campaign_Migration {
+    /**
+     * @throws \Exception  Got error when creating table $name.
+     */
+    public function up() {
+        // Grab the campaign settings
+        $dt_settings = get_site_option( 'dt_campaign_porch_settings' );
+
+        // Isolate the google analytics option if it exists
+        $ga_option = empty( $dt_settings['google_analytics'] ) ? false : $dt_settings['google_analytics'];
+
+        // If the site was previously using a google analytics script, grab the id and replace the script with the id
+        if ( ! empty( $ga_option ) ) {
+            $pattern = '/<script async src="https:\/\/www\.googletagmanager\.com\/gtag\/js\?id=([^"]+)">/';
+
+            if (preg_match($pattern, $ga_option, $matches)) {
+                // The value of 'id' will be captured in $matches[1]
+                $dt_settings['google_analytics'] = $matches[1];
+                update_site_option( 'dt_campaign_porch_settings', $dt_settings );
+            } else {
+                // If an ID wasn't found, remove whatever was there
+                $dt_settings['google_analytics'] = '';
+                update_site_option( 'dt_campaign_porch_settings', $dt_settings );
+            }
+        }
+    }
+
+    /**
+     * @throws \Exception  Got error when dropping table $name.
+     */
+    public function down() {
+    }
+
+    /**
+     * Test function
+     */
+    public function test() {
+    }
+
+}
+
+

--- a/classes/dt-porch-settings.php
+++ b/classes/dt-porch-settings.php
@@ -270,10 +270,10 @@ class DT_Porch_Settings {
                 'tab' => 'settings',
             ],
             'google_analytics' => [
-                'label' => 'Google Analytics (optional)',
+                'label' => 'Google Analytics ID (optional)',
                 'default' => get_site_option( 'p4r_porch_google_analytics' ),
                 'value' => '',
-                'type' => 'textarea',
+                'type' => 'text',
                 'tab' => 'settings',
             ],
             'default_language' => [

--- a/porches/generic/site/header.php
+++ b/porches/generic/site/header.php
@@ -10,7 +10,18 @@ $porch_fields = DT_Porch_Settings::settings();
 ?>
 
 <!-- Required meta tags -->
-<?php echo wp_kses( $porch_fields['google_analytics']['value'] ?: $porch_fields['google_analytics']['default'], $allowed_tags ) ?>
+<?php 
+if ( ! empty( $porch_fields['google_analytics']['value'] ) ) { ?>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<?php esc_attr_e( $porch_fields['google_analytics']['value'] ); ?>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '<?php esc_attr_e( $porch_fields['google_analytics']['value'] );?>');
+</script>
+<?php } ?>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">


### PR DESCRIPTION
- Update form label to ask for GA ID, rather than script.
- Print Google Analytics script in header if ID is present.
- Add migration to replace full GA script with just ID if already exists.