### PR TITLE
PC#200 - Add Edit Buttons To Front End Text

### DIFF
--- a/classes/dt-porch-settings.php
+++ b/classes/dt-porch-settings.php
@@ -119,7 +119,7 @@ class DT_Porch_Settings {
         }
 
         if ( !empty( $changes ) ){
-            DT_Posts::update_post( 'campaigns', $current_campaign['ID'], $changes );
+            DT_Posts::update_post( 'campaigns', $current_campaign['ID'], $changes, false, false );
         }
         return true;
     }

--- a/parts/components-enqueue.php
+++ b/parts/components-enqueue.php
@@ -84,6 +84,18 @@ function dt_campaigns_register_scripts( $atts = [] ){
                     'Prayer Time Selected' => __( 'Prayer Time Selected', 'disciple-tools-prayer-campaigns' ),
                     'Select a Day' => __( 'Select a Day', 'disciple-tools-prayer-campaigns' ),
                     'Renews on %s' => __( 'Renews on %s', 'disciple-tools-prayer-campaigns' ),
+                    'modals' => [
+                        'edit' => [
+                            'modal_title' => __( 'Title & Content Translations', 'disciple-tools-prayer-campaigns' ),
+                            'edit_title' => __( 'Title', 'disciple-tools-prayer-campaigns' ),
+                            'edit_content' => __( 'Content', 'disciple-tools-prayer-campaigns' ),
+                            'edit_translate_type' => __( 'Translation Type', 'disciple-tools-prayer-campaigns' ),
+                            'edit_translate_type_lang_current' => __( 'Currently Selected Language', 'disciple-tools-prayer-campaigns' ),
+                            'edit_translate_type_lang_all' => __( 'All Languages', 'disciple-tools-prayer-campaigns' ),
+                            'edit_btn_close' => __( 'Close', 'disciple-tools-prayer-campaigns' ),
+                            'edit_btn_update' => __( 'Update', 'disciple-tools-prayer-campaigns' )
+                        ]
+                    ]
                 ]
             ]
         );
@@ -93,5 +105,8 @@ function dt_campaigns_register_scripts( $atts = [] ){
         wp_enqueue_script( 'campaign_component_sign_up', $plugin_dir_url . 'parts/campaign-sign-up.js', [ 'campaign_component_css' ], filemtime( $plugin_dir_path . 'parts/campaign-sign-up.js' ), true );
         wp_enqueue_style( 'toastify-js-css', 'https://cdn.jsdelivr.net/npm/toastify-js@1.12.0/src/toastify.min.css', [], '1.12.0' );
         wp_enqueue_script( 'toastify-js', 'https://cdn.jsdelivr.net/npm/toastify-js@1.12.0/src/toastify.min.js', [ 'jquery' ], '1.12.0' );
+
+        wp_enqueue_script( 'foundation-js', 'https://cdn.jsdelivr.net/npm/foundation-sites@6.8.1/dist/js/foundation.min.js', [ 'jquery' ], '6.8.1' );
+        wp_enqueue_style( 'foundation-js-css', 'https://cdn.jsdelivr.net/npm/foundation-sites@6.8.1/dist/css/foundation.min.css', [], '6.8.1' );
     }
 }

--- a/porches/generic/site/home-body.php
+++ b/porches/generic/site/home-body.php
@@ -40,17 +40,30 @@ if ( $dt_campaign_selected_campaign_magic_link_settings['color'] === 'preset' ){
 }
 ?>
 
+<!-- MODALS -->
+<?php
+require_once( get_theme_file_path( 'dt-assets/parts/modals/modal-support.php' ) );
+?>
+<!-- MODALS -->
+
 <!-- Vision -->
 <section id="campaign-vision" class="section">
     <div class="container">
         <div class="section-header row">
             <div class="col-sm-12 col-md-8">
-                <h2 class="section-title wow fadeIn" data-wow-duration="1000ms" data-wow-delay="0.3s">
+                <h2 id="vision_section_title" class="section-title wow fadeIn" data-wow-duration="1000ms" data-wow-delay="0.3s">
                     <?php echo esc_html( dt_split_sentence( DT_Porch_Settings::get_field_translation( 'vision_title' ), 1, 2 ) ) ?> <span><?php echo esc_html( dt_split_sentence( DT_Porch_Settings::get_field_translation( 'vision_title' ), 2, 2 ) ) ?></span>
                 </h2>
                 <hr class="lines wow zoomIn" data-wow-delay="0.3s">
                 <div style="padding: 2em">
-                <p class="section-subtitle wow fadeIn" data-wow-duration="1000ms" data-wow-delay="0.3s" style="padding:2em">
+                <?php
+                if ( is_user_logged_in() ) {
+                    ?>
+                    <button class="btn btn-common edit-btn" style="font-size: 10px; padding: 5px 15px;" data-edit_key="vision_section" data-edit_title_id="vision_section_title" data-edit_text_id="vision_section_text"><?php esc_html_e( 'Edit', 'disciple-tools-prayer-campaigns' ); ?></button>
+                    <?php
+                }
+                ?>
+                <p id="vision_section_text" class="section-subtitle wow fadeIn" data-wow-duration="1000ms" data-wow-delay="0.3s" style="padding:2em">
                     <?php echo nl2br( wp_kses( DT_Porch_Settings::get_field_translation( 'vision' ), $allowedtags ) ); ?>
                 </p>
                 </div>
@@ -67,8 +80,15 @@ if ( $dt_campaign_selected_campaign_magic_link_settings['color'] === 'preset' ){
                     <div class="icon">
                         <img class="<?php echo !empty( $porch_fields['pray_section_icon']['value'] ) ? '' : 'color-img'?>" style="height: 40px; margin-top:10px" src="<?php echo esc_html( DT_Porch_Settings::get_field_translation( 'pray_section_icon' ) ) ?>" alt="Praying hands icon"/>
                     </div>
-                    <h4><?php echo esc_html( DT_Porch_Settings::get_field_translation( 'pray_section_title' ) ) ?></h4>
-                    <p><?php echo wp_kses( DT_Porch_Settings::get_field_translation( 'pray_section_text' ), $allowedtags ) ?></p>
+                    <h4 id="pray_section_title" class="section-title"><?php echo esc_html( DT_Porch_Settings::get_field_translation( 'pray_section_title' ) ) ?></h4>
+                    <?php
+                    if ( is_user_logged_in() ) {
+                        ?>
+                        <button class="btn btn-common edit-btn" style="font-size: 10px; padding: 5px 15px;" data-edit_key="pray_section" data-edit_title_id="pray_section_title" data-edit_text_id="pray_section_text"><?php esc_html_e( 'Edit', 'disciple-tools-prayer-campaigns' ); ?></button>
+                        <?php
+                    }
+                    ?>
+                    <p id="pray_section_text" class="section-text"><?php echo wp_kses( DT_Porch_Settings::get_field_translation( 'pray_section_text' ), $allowedtags ) ?></p>
                 </div>
             </div>
             <div class="col-md-4 col-sm-6">
@@ -76,8 +96,15 @@ if ( $dt_campaign_selected_campaign_magic_link_settings['color'] === 'preset' ){
                     <div class="icon">
                         <img class="<?php echo !empty( $porch_fields['movement_section_icon']['value'] ) ? '' : 'color-img'?>" style="height: 40px; margin-top:10px" src="<?php echo esc_html( DT_Porch_Settings::get_field_translation( 'movement_section_icon' ) ) ?>" alt="Movement icon"/>
                     </div>
-                    <h4><?php echo esc_html( DT_Porch_Settings::get_field_translation( 'movement_section_title' ) ) ?></h4>
-                    <p><?php echo wp_kses( DT_Porch_Settings::get_field_translation( 'movement_section_text' ), $allowedtags ) ?></p>
+                    <h4 id="movement_section_title" class="section-title"><?php echo esc_html( DT_Porch_Settings::get_field_translation( 'movement_section_title' ) ) ?></h4>
+                    <?php
+                    if ( is_user_logged_in() ) {
+                        ?>
+                        <button class="btn btn-common edit-btn" style="font-size: 10px; padding: 5px 15px;" data-edit_key="movement_section" data-edit_title_id="movement_section_title" data-edit_text_id="movement_section_text"><?php esc_html_e( 'Edit', 'disciple-tools-prayer-campaigns' ); ?></button>
+                        <?php
+                    }
+                    ?>
+                    <p id="movement_section_text" class="section-text"><?php echo wp_kses( DT_Porch_Settings::get_field_translation( 'movement_section_text' ), $allowedtags ) ?></p>
                 </div>
             </div>
             <div class="col-md-4 col-sm-6">
@@ -85,8 +112,15 @@ if ( $dt_campaign_selected_campaign_magic_link_settings['color'] === 'preset' ){
                     <div class="icon">
                         <img class="<?php echo !empty( $porch_fields['time_section_icon']['value'] ) ? '' : 'color-img'?>" style="height: 40px; margin-top:10px" src="<?php echo esc_html( DT_Porch_Settings::get_field_translation( 'time_section_icon' ) ) ?>" alt="Clock icon"/>
                     </div>
-                    <h4><?php echo esc_html( DT_Porch_Settings::get_field_translation( 'time_section_title' ) ) ?></h4>
-                    <p><?php echo wp_kses( DT_Porch_Settings::get_field_translation( 'time_section_text' ), $allowedtags ) ?></p>
+                    <h4 id="time_section_title" class="section-title"><?php echo esc_html( DT_Porch_Settings::get_field_translation( 'time_section_title' ) ) ?></h4>
+                    <?php
+                    if ( is_user_logged_in() ) {
+                        ?>
+                        <button class="btn btn-common edit-btn" style="font-size: 10px; padding: 5px 15px;" data-edit_key="time_section" data-edit_title_id="time_section_title" data-edit_text_id="time_section_text"><?php esc_html_e( 'Edit', 'disciple-tools-prayer-campaigns' ); ?></button>
+                        <?php
+                    }
+                    ?>
+                    <p id="time_section_text" class="section-text"><?php echo wp_kses( DT_Porch_Settings::get_field_translation( 'time_section_text' ), $allowedtags ) ?></p>
                 </div>
             </div>
         </div>
@@ -116,8 +150,19 @@ if ( $dt_campaign_selected_campaign_magic_link_settings['color'] === 'preset' ){
                 </div>
             </div>
         </div>
+        <div id="counter_row" class="row">
+            <div class="col-sm-12">
+                <?php
+                if ( is_user_logged_in() ) {
+                    ?>
+                    <button class="btn btn-border edit-btn" style="font-size: 12px; padding: 5px 15px;" data-edit_key="what_section" data-edit_title_id="" data-edit_text_id="what_section_text"><?php esc_html_e( 'Edit', 'disciple-tools-prayer-campaigns' ); ?></button>
+                    <?php
+                }
+                ?>
+            </div>
+        </div>
         <div class="row" style="margin-top: 30px">
-            <div class="col-sm-12 col-md-8 what-content-text">
+            <div id="what_section_text" class="col-sm-12 col-md-8 what-content-text">
                 <?php
                     echo wp_kses( DT_Porch_Settings::get_field_translation( 'what_content' ), $allowedtags );
                 ?>
@@ -233,9 +278,17 @@ if ( $dt_campaign_selected_campaign_magic_link_settings['color'] === 'preset' ){
     <!-- Container Starts -->
     <div class="container">
         <div class="section-header">
-            <h2 class="section-title split-color wow fadeIn" data-wow-duration="1000ms" data-wow-delay="0.3s"><?php echo esc_html( dt_split_sentence( DT_Porch_Settings::get_field_translation( 'prayer_fuel_title' ), 1, 2 ) ) ?> <span><?php echo esc_html( dt_split_sentence( DT_Porch_Settings::get_field_translation( 'prayer_fuel_title' ), 2, 2 ) ) ?></span> </h2>
+            <h2 id="prayer_fuel_section_title" class="section-title split-color wow fadeIn" data-wow-duration="1000ms" data-wow-delay="0.3s"><?php echo esc_html( dt_split_sentence( DT_Porch_Settings::get_field_translation( 'prayer_fuel_title' ), 1, 2 ) ) ?> <span><?php echo esc_html( dt_split_sentence( DT_Porch_Settings::get_field_translation( 'prayer_fuel_title' ), 2, 2 ) ) ?></span> </h2>
             <hr class="lines wow zoomIn" data-wow-delay="0.3s">
-            <p class="section-subtitle wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="0.3s"><?php echo esc_html( DT_Porch_Settings::get_field_translation( 'prayer_fuel_description' ) ); ?></p>
+            <?php
+            if ( is_user_logged_in() ) {
+                ?>
+                <div style="padding: 2em">
+                <button class="btn btn-common edit-btn" style="font-size: 10px; padding: 5px 15px;" data-edit_key="prayer_fuel_section" data-edit_title_id="prayer_fuel_section_title" data-edit_text_id="prayer_fuel_section_text"><?php esc_html_e( 'Edit', 'disciple-tools-prayer-campaigns' ); ?></button>
+                <?php
+            }
+            ?>
+            <p id="prayer_fuel_section_text" class="section-subtitle wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="0.3s"><?php echo esc_html( DT_Porch_Settings::get_field_translation( 'prayer_fuel_description' ) ); ?></p>
             <p class="section-subtitle wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="0.3s"><a href="<?php echo esc_html( site_url( '/list' ) ); ?>" class="btn btn-common btn-rm"><?php esc_html_e( 'View All', 'disciple-tools-prayer-campaigns' ); ?></a></p>
         </div>
     </div>


### PR DESCRIPTION
- fixes: #200 
---

- Functionality has been added to support the dynamic updating of front-end section titles and description text, across main sections.
- Access to admin area no longer required to update text.

![Screenshot 2023-11-24 at 15 37 33](https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/19330800/4f08c71e-3ac0-4cf3-b0e6-f67b4931df6b)

![Screenshot 2023-11-24 at 15 38 01](https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/19330800/3f7efa6c-c6a6-489a-a1bf-7a4fd6a1340d)

![Screenshot 2023-11-24 at 15 38 27](https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/19330800/0539c82e-6332-44e7-8599-0cb4402c174c)

![Screenshot 2023-11-24 at 15 38 50](https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/19330800/1f76c305-d092-4ebe-8fe0-3d7a3b5d4e46)

![Screenshot 2023-11-24 at 15 39 17](https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/19330800/42a9aed2-fc86-40cc-98f0-364362200c1a)
