### PR TITLE
Ability to create extra text and bool fields in subscriber sign up.

### DIFF
--- a/parts/campaign-components.js
+++ b/parts/campaign-components.js
@@ -257,8 +257,11 @@ export class ContactInfo extends LitElement {
     this._form_items = {
       email: '',
       name: '',
-      receive_pray4movement_news: false,
+      receive_pray4movement_news: true,
     }
+    window.campaign_data.signup_form_fields?.map(f=>{
+      this._form_items[f.key] = f.default || null;
+    })
     this.selected_times_count = 0;
   }
 
@@ -267,8 +270,7 @@ export class ContactInfo extends LitElement {
   }
 
   handleInput(e){
-    console.log(e);
-    let val = e.target.value
+    let val = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
     let name = e.target.name
     this._form_items[name] = val
     this.requestUpdate()
@@ -282,7 +284,6 @@ export class ContactInfo extends LitElement {
     if ( this._form_items.EMAIL){
       return;
     }
-    console.log(this._form_items);
 
     if ( !this._form_items.name || !this._is_email(this._form_items.email) ){
       this.form_error = strings['Please enter a valid name or email address']
@@ -309,11 +310,43 @@ export class ContactInfo extends LitElement {
       </div>
       ${ window.campaign_objects.dt_campaigns_is_p4m_news_enabled ? 
           html`<label for="receive_pray4movement_news" style="font-weight: normal; display: block">
-                <input type="checkbox" id="receive_pray4movement_news" name="receive_pray4movement_news" @input=${this.handleInput}/>
+                <input type="checkbox" checked id="receive_pray4movement_news" name="receive_pray4movement_news" @input=${this.handleInput}/>
                 ${translate('Receive Pray4Movement news and opportunities, and occasional communication from GospelAmbition.org.')}
           </label>`
       : ``}
-      </div>
+      
+      <!-- Additional Fields -->
+      ${ window.campaign_data.signup_form_fields?.map(f=>{
+        let key = window.campaign_scripts.escapeHTML(f.key)
+        let name = window.campaign_scripts.escapeHTML(f.name)
+        let description = window.campaign_scripts.escapeHTML(f.description)
+        if ( f.type === 'text' ){
+          return html`
+            <div>
+                <label for="${key}">${name}<br>
+                    <input 
+                        class="cp-input" 
+                        type="text" name="${key}" id="${key}" placeholder="${description}" @input=${this.handleInput}/>
+                </label>
+            </div>
+          `
+        } else if ( f.type === 'boolean' ){
+          return html`
+            <div>
+                <label for="${key}" style="font-weight: normal; display: block">
+                    <input 
+                        type="checkbox"
+                        name="${key}" 
+                        id="${key}"
+                        ?checked=${f.default}
+                        @input=${this.handleInput}/>
+                    ${description || name}
+                </label>
+            </div>
+          `
+        }
+      } ) }
+      
       <div>
           <div id='cp-no-selected-times' style='display: none' class="form-error" >
               ${strings['No prayer times selected']}

--- a/parts/campaign-sign-up.js
+++ b/parts/campaign-sign-up.js
@@ -158,7 +158,7 @@ export class CampaignSignUp extends LitElement {
     this._form_items = {
       email: '',
       name: '',
-      receive_pray4movement_news: false,
+      receive_pray4movement_news: true,
     }
     this.now = new Date().getTime()/1000
     this.selected_day = null;
@@ -232,13 +232,13 @@ export class CampaignSignUp extends LitElement {
     let selected_times = this.selected_times;
 
     let data = {
-      name: this._form_items.name,
-      email: this._form_items.email,
-      code: this._form_items.code,
-      receive_pray4movement_news: this._form_items.receive_pray4movement_news,
       selected_times: selected_times,
       recurring_signups: this.recurring_signups,
     }
+    //add this._form_items
+    Object.keys(this._form_items).forEach(key=>{
+      data[key] = this._form_items[key]
+    })
 
     window.campaign_scripts.submit_prayer_times(this.campaign_data.campaign_id, data)
     .done((response)=>{

--- a/post-type/subscriptions.php
+++ b/post-type/subscriptions.php
@@ -325,6 +325,10 @@ class DT_Subscriptions_Base {
         if ( $post_type === $this->post_type ){
             $tiles['commitments'] = [ 'label' => __( 'Commitments', 'disciple-tools-subscriptions' ) ];
             $tiles['other'] = [ 'label' => __( 'Other', 'disciple-tools-prayer-campaigns' ) ];
+            $tiles['signup_form'] = [
+                'label' => __( 'Extra Signup Form Fields', 'disciple-tools-prayer-campaigns' ),
+                'description' => '',
+            ];
         }
 
         return $tiles;


### PR DESCRIPTION
## Create 2 custom fields on the **Subscriptions** record type in the **Extra Signup Form Fields** tile.
- **Text** field: WhatsApp Number
- **Boolean** field: Sign up to the Newsletter

Note: Only text and boolean are currently supported.

<img width="688" alt="image" src="https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/24901539/afd90632-1194-4174-8984-e69c10e5a230">


## See your new fields in the sign up form:

<img width="455" alt="image" src="https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/24901539/4d7ed1b2-9f24-4fb4-b31e-7c7c3fea87eb">


## Fields are saved on Jonny's subscription record:
<img width="852" alt="image" src="https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/24901539/19a48dcc-16ba-4b35-8ab4-eab04f3e392d">

