### PR TITLE
PC#272 - Ability To Clear Custom Theme Colors

### DIFF
--- a/classes/dt-porch-admin-tab-base.php
+++ b/classes/dt-porch-admin-tab-base.php
@@ -87,6 +87,8 @@ class DT_Porch_Admin_Tab_Base {
 
         if ( isset( $_POST['generic_porch_settings_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['generic_porch_settings_nonce'] ) ), 'generic_porch_settings' ) ) {
 
+            $states = isset( $_POST['states'] ) ? dt_recursive_sanitize_array( $_POST['states'] ) : [];
+
             if ( isset( $_POST['list'] ) ) {
                 $post_list = dt_recursive_sanitize_array( $_POST['list'] );
                 $allowed_tags = $this->get_allowed_tags();
@@ -97,7 +99,7 @@ class DT_Porch_Admin_Tab_Base {
                         $post_list[$field_key] = wp_kses( wp_unslash( $_POST['list'][$field_key] ), $allowed_tags );
                     }
                 }
-                DT_Porch_Settings::update_values( $post_list );
+                DT_Porch_Settings::update_values( $post_list, null, $states );
 
                 $new_translations = $this->get_new_translations( $_POST );
                 DT_Porch_Settings::update_translations( $campaign['ID'], $new_translations );
@@ -183,9 +185,18 @@ class DT_Porch_Admin_Tab_Base {
                                                 <img style="height: 15px; vertical-align: middle" src="<?php echo esc_html( get_template_directory_uri() . '/dt-assets/images/languages.svg' ); ?>">
                                                 button to set a value for each language:</p>
                                         <?php endif; ?>
-                                        <input style="width: 100%" type="<?php echo esc_html( $field['type'] ); ?>" name="list[<?php echo esc_html( $key ); ?>]" id="<?php echo esc_html( $key ); ?>" value="<?php echo esc_html( $campaign[$key] ?? '' ); ?>" placeholder="<?php echo esc_html( $field['description'] ?? $field['name'] ); ?>"/>
+                                        <?php if ( $field['type'] === 'color' ) { ?>
+                                            <input style="width: 100%" type="<?php echo esc_html( $field['type'] ); ?>" name="list[<?php echo esc_html( $key ); ?>]" id="<?php echo esc_html( $key ); ?>" value="<?php echo esc_html( $campaign[$key] ?? '' ); ?>" placeholder="<?php echo esc_html( $field['description'] ?? $field['name'] ); ?>"
+                                                onChange="jQuery('#<?php echo esc_html( $key ); ?>_state').val('');"/>
+                                        <?php } else { ?>
+                                            <input style="width: 100%" type="<?php echo esc_html( $field['type'] ); ?>" name="list[<?php echo esc_html( $key ); ?>]" id="<?php echo esc_html( $key ); ?>" value="<?php echo esc_html( $campaign[$key] ?? '' ); ?>" placeholder="<?php echo esc_html( $field['description'] ?? $field['name'] ); ?>"/>
+                                        <?php } ?>
                                     </td>
                                     <td style="vertical-align: middle;">
+                                        <?php if ( $field['type'] === 'color' ) { ?>
+                                            <i class="mdi mdi-backup-restore" style="font-size: 20px; cursor: pointer;" onClick="jQuery('#<?php echo esc_html( $key ); ?>').val(''); jQuery('#<?php echo esc_html( $key ); ?>_state').val('reset');"></i>
+                                            <input type="hidden" name="states[<?php echo esc_html( $key ); ?>]" id="<?php echo esc_html( $key ); ?>_state" value="<?php echo esc_html( empty( $campaign[$key] ) ? 'reset' : $campaign[$key] ); ?>" />
+                                        <?php } ?>
                                         <?php if ( isset( $field['translations'] ) ){
                                             self::translation_cell( $langs, $key, $field, $section_name );
                                         } ?>

--- a/classes/dt-porch-settings.php
+++ b/classes/dt-porch-settings.php
@@ -102,7 +102,7 @@ class DT_Porch_Settings {
         return DT_Campaign_Languages::get_translations( $campaign_id );
     }
 
-    public static function update_values( $updates, $campaign_id = null ) {
+    public static function update_values( $updates, $campaign_id = null, $states = [] ) {
         $current_campaign = DT_Campaign_Landing_Settings::get_campaign( $campaign_id );
         $campaign_field_settings = DT_Posts::get_post_field_settings( 'campaigns' );
 
@@ -118,6 +118,11 @@ class DT_Porch_Settings {
                     $changes[$key] = $value;
                 }
             }
+        }
+
+        // Observe custom states, to alter generic flows.
+        if ( isset( $states['custom_theme_color'] ) && $states['custom_theme_color'] === 'reset' ) {
+            $changes['custom_theme_color'] = '';
         }
 
         if ( !empty( $changes ) ){


### PR DESCRIPTION
- fixes: #272 
---

![Screenshot 2024-02-06 at 12 21 07](https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/19330800/1be57e32-864a-4289-8300-0b4770c55a8c)

- Added ability to reset the `Custom Theme Color`; which then defaults to using selected `Theme Color`, until a new custom theme colour is again chosen.