### PR TITLE
Better setup wizard for fixed and ongoing 24/7 campaigns

### DIFF
--- a/admin/dt-prayer-campaigns.php
+++ b/admin/dt-prayer-campaigns.php
@@ -42,7 +42,7 @@ class DT_Prayer_Campaigns_Campaigns {
         }
 
         $fields = [
-            'name' => 'Campaign',
+            'name' => 'Prayer Campaign',
             'start_date' => dt_format_date( time(), 'Y-m-d' ),
             'status' => 'active',
         ];
@@ -52,9 +52,8 @@ class DT_Prayer_Campaigns_Campaigns {
             $fields['start_date'] = $next_ramadan_start_date;
             $fields['end_date'] = $next_ramadan_start_date + 30 * DAY_IN_SECONDS;
             $fields['name'] = 'Ramadan Campaign';
-        } else {
+        } else if ( $wizard_type === 'generic' ) {
             $fields['end_date'] = dt_format_date( time() + 30 * DAY_IN_SECONDS, 'Y-m-d' );
-            $fields['name'] = 'Prayer Campaign';
         }
 
         if ( $new_campaign_name ) {

--- a/porches/generic/dt-generic-porch-loader.php
+++ b/porches/generic/dt-generic-porch-loader.php
@@ -37,7 +37,11 @@ class DT_Generic_Porch_Loader implements IDT_Porch_Loader {
         $default_wizards = [
             'generic' => [
                 'porch' => 'generic-porch',
-                'label' => '24/7 Campaign with a start and optional end date'
+                'label' => '24/7 Campaign with a start and end date'
+            ],
+            'ongoing' => [
+                'porch' => 'generic-porch',
+                'label' => '24/7 Campaign with a start date and no end date'
             ],
         ];
         return array_merge( $default_wizards, $wizard_types );


### PR DESCRIPTION
Now:
<img width="494" alt="image" src="https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/24901539/b942ae83-5b48-404d-bd0e-b520fa5b9c5b">

Was:
<img width="452" alt="image" src="https://github.com/DiscipleTools/disciple-tools-prayer-campaigns/assets/24901539/8f5efa1e-f873-4c26-9771-e14c5282f869">
