### PR TITLE
Header image settable default

### DIFF
--- a/classes/dt-porch-settings.php
+++ b/classes/dt-porch-settings.php
@@ -35,16 +35,17 @@ class DT_Porch_Settings {
 //            }
 
             $defaults[$key] = $field;
-            $defaults[$key]['value'] = $field['type'] === 'key_select' ? '' : ( $field['default'] ?? '' );
-            if ( isset( $current_campaign[$key] ) ) {
-                if ( $field['type'] === 'key_select' ){
-                    $defaults[$key]['value'] = $current_campaign[$key]['key'];
-                } else {
-                    $defaults[$key]['value'] = $current_campaign[$key];
+            if ( !isset( $defaults[$key]['value'] ) ) {
+                $defaults[$key]['value'] = $field['type'] === 'key_select' ? '' : ( $field['default'] ?? '' );
+                if ( isset( $current_campaign[$key] ) ) {
+                    if ( $field['type'] === 'key_select' ){
+                        $defaults[$key]['value'] = $current_campaign[$key]['key'];
+                    } else {
+                        $defaults[$key]['value'] = $current_campaign[$key];
+                    }
                 }
             }
         }
-
         /**
          * Filter to allow the defaults to be changed according to the saved settings and the current language
          *

--- a/classes/dt-porch-settings.php
+++ b/classes/dt-porch-settings.php
@@ -37,12 +37,12 @@ class DT_Porch_Settings {
             $defaults[$key] = $field;
             if ( !isset( $defaults[$key]['value'] ) ) {
                 $defaults[$key]['value'] = $field['type'] === 'key_select' ? '' : ( $field['default'] ?? '' );
-                if ( isset( $current_campaign[$key] ) ) {
-                    if ( $field['type'] === 'key_select' ){
-                        $defaults[$key]['value'] = $current_campaign[$key]['key'];
-                    } else {
-                        $defaults[$key]['value'] = $current_campaign[$key];
-                    }
+            }
+            if ( isset( $current_campaign[$key] ) && !empty( $current_campaign[$key] ) ) {
+                if ( $field['type'] === 'key_select' ){
+                    $defaults[$key]['value'] = $current_campaign[$key]['key'];
+                } else {
+                    $defaults[$key]['value'] = $current_campaign[$key];
                 }
             }
         }

--- a/porches/generic/site/header.php
+++ b/porches/generic/site/header.php
@@ -7,8 +7,6 @@ $allowed_tags['script'] = array(
     'src' => array()
 );
 $porch_fields = DT_Porch_Settings::settings();
-dt_write_log('header image check');
-dt_write_log($porch_fields['header_background_url'])
 ?>
 
 <!-- Required meta tags -->

--- a/porches/generic/site/header.php
+++ b/porches/generic/site/header.php
@@ -7,6 +7,8 @@ $allowed_tags['script'] = array(
     'src' => array()
 );
 $porch_fields = DT_Porch_Settings::settings();
+dt_write_log('header image check');
+dt_write_log($porch_fields['header_background_url'])
 ?>
 
 <!-- Required meta tags -->


### PR DESCRIPTION
I have a plugin based off the Ramadan plugin, I wanted to set the default header image to something other than the stencil image, but allow the user to change it like normal [https://github.com/micahmills/DE-Prayer-2024/blob/29f68fa91b33df051af48b0352a1344ad858c012/porch/de-porch-settings.php#L29](url)

The value was value was being overwritten in this loop and the image was not being displayed. This adds a check to see if a value is set as a default, and also only overwrites it if the campaign settings aren't empty