### PR TITLE
Loads the wp-block-library css 

### DIFF
--- a/magic-links/campaign-magic-link.php
+++ b/magic-links/campaign-magic-link.php
@@ -167,6 +167,7 @@ class DT_Prayer_Campaign_Magic_Link extends DT_Magic_Url_Base {
             'menu_sideslide',
             'responsive',
             'p4m-colors',
+            'wp-block-library',
         ];
     }
     public function add_api_routes(){


### PR DESCRIPTION
Loads the wp-block-library css to the Prayer Fuel pages so you can use the Wordpress blocks correctly from the WP Editor