### PR TITLE
toLocalString fix

### DIFF
--- a/parts/campaign-components.js
+++ b/parts/campaign-components.js
@@ -592,7 +592,7 @@ export class cpCalendarDaySelect extends LitElement {
                     @click="${e=>this.next_view(previous_month)}">
                 <
             </button>
-            ${month_date.toLocaleString({ month: 'short', year: 'numeric' })}
+            ${month_date.toLocaleString({ month: 'long', year: 'numeric' })}
             <button class="month-next" ?disabled="${next_month > this.end_timestamp}" @click="${e=>this.next_view(next_month)}">
                 >
             </button>
@@ -781,7 +781,7 @@ export class cpMyCalendar extends LitElement {
                     @click="${e=>this.next_view(previous_month)}">
                 <
             </button>
-            ${month_date.toLocaleString({ month: 'short', year: 'numeric' })} }
+            ${month_date.toLocaleString({ month: 'long', year: 'numeric' })} }
             <button class="month-next" ?disabled="${next_month > this.end_timestamp}" @click="${e=>this.next_view(next_month)}">
                 >
             </button>

--- a/parts/campaign-components.js
+++ b/parts/campaign-components.js
@@ -592,7 +592,7 @@ export class cpCalendarDaySelect extends LitElement {
                     @click="${e=>this.next_view(previous_month)}">
                 <
             </button>
-            ${month_date.toFormat('MMMM y')}
+            ${month_date.toLocaleString({ month: 'short', year: 'numeric' })}
             <button class="month-next" ?disabled="${next_month > this.end_timestamp}" @click="${e=>this.next_view(next_month)}">
                 >
             </button>
@@ -781,7 +781,7 @@ export class cpMyCalendar extends LitElement {
                     @click="${e=>this.next_view(previous_month)}">
                 <
             </button>
-            ${month_date.toFormat('MMMM y')}
+            ${month_date.toLocaleString({ month: 'short', year: 'numeric' })} }
             <button class="month-next" ?disabled="${next_month > this.end_timestamp}" @click="${e=>this.next_view(next_month)}">
                 >
             </button>
@@ -982,13 +982,13 @@ export class cpTimes extends LitElement {
           <div class="times-section">
             <div class="section-column time-column">
               <div>&nbsp;</div>
-               ${map(range(time_slots),i=>html`<div class="grid-cell">${this.times[i].minute}</div>`)} 
+               ${map(range(time_slots),i=>html`<div class="grid-cell">${this.times[i].minute}</div>`)}
             </div>
-            
+
             ${map(range(6),i => {
               index = i + row * 6
               return html`
-                
+
               ${ this.times[index*time_slots] ? html`
               <div class="section-column">
                   <div class="prayer-hour">

--- a/parts/campaign-sign-up.js
+++ b/parts/campaign-sign-up.js
@@ -1002,7 +1002,7 @@ export class cpCalendar extends LitElement {
             ${months_to_show.map(month=>html`
                 <div class="calendar-month">
                     <h3 class="month-title center">
-                        ${month.date.toFormat( 'MMM y')}
+                        ${month.date.toLocaleString({ month: 'short', year: 'numeric' })} }
                         <span class="month-percentage">${ month.percentage || 0 }% | ${month.days_covered} ${translate('days')}</span>
 
                     </h3>

--- a/parts/campaign-sign-up.js
+++ b/parts/campaign-sign-up.js
@@ -1002,7 +1002,7 @@ export class cpCalendar extends LitElement {
             ${months_to_show.map(month=>html`
                 <div class="calendar-month">
                     <h3 class="month-title center">
-                        ${month.date.toLocaleString({ month: 'short', year: 'numeric' })} }
+                        ${month.date.toLocaleString({ month: 'short', year: 'numeric' })}
                         <span class="month-percentage">${ month.percentage || 0 }% | ${month.days_covered} ${translate('days')}</span>
 
                     </h3>


### PR DESCRIPTION
Use `.toLocaleString({ month: 'short', year: 'numeric' })} ` instead of `.toFormat('MMMM y')`