### PR TITLE
Add hook for whatsapp notifications

### DIFF
--- a/campaign-functions/cron-schedule.php
+++ b/campaign-functions/cron-schedule.php
@@ -30,7 +30,7 @@ function dt_prayer_campaign_prayer_time_reminder(){
      * Where notification has not been sent (no 'prayer_time_reminder_sent' meta)
      * Of prayer time happening in the next x hours
      */
-    $reminders = $wpdb->get_results($wpdb->prepare(
+    $reminders = $wpdb->get_results( $wpdb->prepare(
         "SELECT r.id, r.parent_id, r.post_id, r.time_begin, r.time_end, pm.meta_value as email, r.label, pk.meta_value as public_key, p.post_title as name
             FROM $wpdb->dt_reports r
             LEFT JOIN $wpdb->postmeta pm ON pm.post_id=r.post_id
@@ -98,6 +98,9 @@ function dt_prayer_campaign_prayer_time_reminder(){
                     Disciple_Tools_Reports::add_meta( $row['id'], 'prayer_time_reminder_sent', time() );
                 }
             }
+
+            //hook for other notification channels
+            do_action( 'dt_prayer_campaign_prayer_time_reminder', $record, $reports, $campaign_id );
         } // user loop
 
     } // campaign loop

--- a/campaign-functions/wa-notifications.php
+++ b/campaign-functions/wa-notifications.php
@@ -11,8 +11,8 @@ class Prayer_Campaign_WhatsApp_Notifications {
         add_filter( 'dt_twilio_messaging_templates', [ $this, 'dt_twilio_messaging_templates' ], 10, 1 );
     }
 
-    public function dt_custom_fields_settings( $fields, $type ){
-        if ( $type === 'campaigns' ){
+    public function dt_custom_fields_settings( $fields, $post_type ){
+        if ( $post_type === 'subscriptions' ){
             $fields['whatsapp_number'] = [
                 'type' => 'text',
                 'label' => 'WhatsApp # for Notifications',

--- a/campaign-functions/wa-notifications.php
+++ b/campaign-functions/wa-notifications.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Integrate with the twilio plugin to send whatsapp notifications
+ */
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Prayer_Campaign_WhatsApp_Notifications {
+    public function __construct(){
+        add_filter( 'dt_custom_fields_settings', [ $this, 'dt_custom_fields_settings' ], 10, 2 );
+        add_action( 'dt_prayer_campaign_prayer_time_reminder', [ $this, 'dt_prayer_campaign_prayer_time_reminder' ], 10, 3 );
+        add_filter( 'dt_twilio_messaging_templates', [ $this, 'dt_twilio_messaging_templates' ], 10, 1 );
+    }
+
+    public function dt_custom_fields_settings( $fields, $type ){
+        if ( $type === 'campaigns' ){
+            $fields['whatsapp_number'] = [
+                'type' => 'text',
+                'label' => 'WhatsApp # for Notifications',
+                'description' => 'Include a country code like +33',
+                'tile' => 'signup_form',
+                'default' => '',
+                'hidden' => true,
+            ];
+        }
+        return $fields;
+    }
+
+    public function dt_twilio_messaging_templates( $templates ){
+        $templates['prayer_fuel_notification'] = [
+            'id' => 'prayer_fuel_notification',
+            'name' => 'Prayer Fuel Notifications',
+            'type' => 'whatsapp',
+            'enabled' => true,
+            'content_category' => 'UTILITY',
+            'content_template' => [
+                'friendly_name' => 'Prayer Fuel Notifications',
+                'language' => 'en',
+                'variables' => [
+                    '1' => 'https://ramadandemo.pray4movement.org/list',
+                ],
+                'types' => [
+                    'twilio/text' => [
+                        'body' => 'Your prayer time is approaching. Here is a link to the prayer fuel: {{1}}.\n\nThank you for praying with us.'
+                    ]
+                ]
+            ]
+        ];
+        return $templates;
+    }
+
+    public function dt_prayer_campaign_prayer_time_reminder( $subscriber, $reports, $campaign_id ){
+        if ( empty( $subscriber['whatsapp_number'] ) ){
+            return;
+        }
+        $phone_number = $subscriber['whatsapp_number'];
+        $prayer_fuel_link = DT_Prayer_Campaigns_Send_Email::prayer_fuel_link( $subscriber, $campaign_id );
+
+        //sort reports by time ascending
+        usort( $reports, function( $a, $b ){
+            return $a['time_begin'] <=> $b['time_begin'];
+        } );
+
+        $prayer_fuel_time = $reports[0]['time_begin'];
+        $fifteen_mints_before = $prayer_fuel_time - MINUTE_IN_SECONDS * 15;
+        $now = time();
+        $from_now = $fifteen_mints_before - $now;
+
+        wp_queue()->push( new Prayer_Campaign_WhatsApp_Notifications_Job( $phone_number, $prayer_fuel_link ), $from_now );
+    }
+    public static function send_whatsapp_notification( $phone_number, $prayer_fuel_link ){
+        $sent = Disciple_Tools_Twilio_API::send_dt_notification_template(
+            $phone_number,
+            [
+                '1' => $prayer_fuel_link,
+            ],
+            'prayer_fuel_notification',
+        );
+        if ( ! $sent ){
+            dt_write_log( __METHOD__ . ': Unable to send whatsapp to ' . $phone_number );
+        }
+        return $sent;
+    }
+}
+new Prayer_Campaign_WhatsApp_Notifications();
+
+use WP_Queue\Job;
+class Prayer_Campaign_WhatsApp_Notifications_Job extends Job {
+    public $phone_number;
+    public $prayer_fuel_link;
+    public function __construct( $phone_number, $prayer_fuel_link ){
+        $this->phone_number = $phone_number;
+        $this->prayer_fuel_link = $prayer_fuel_link;
+    }
+    public function handle(){
+        Prayer_Campaign_WhatsApp_Notifications::send_whatsapp_notification( $this->phone_number, $this->prayer_fuel_link );
+    }
+}

--- a/disciple-tools-prayer-campaigns.php
+++ b/disciple-tools-prayer-campaigns.php
@@ -119,6 +119,7 @@ class DT_Prayer_Campaigns {
         require_once( 'campaign-functions/time-utilities.php' );
         require_once( 'campaign-functions/send-email-utility.php' );
         require_once( 'campaign-functions/cron-schedule.php' );
+        require_once( 'campaign-functions/wa-notifications.php' );
 
         require_once( 'post-type/loader.php' );
         require_once( 'classes/dt-campaign-fuel.php' );


### PR DESCRIPTION
Ask the user for their whatsapp number
<img width="466" alt="image" src="https://github.com/user-attachments/assets/a4ca07e3-7421-4d77-acb4-a1ff9ec62e7a">

This will send a whatsapp message 0 to 15mins before their prayer time.

Requires twilio with whatsapp, the dt twilio plugin and prayer fuel template to be  set up