### PR TITLE
removed $ reference of jQuery and switched it to jQuery directly

### DIFF
--- a/shortcodes/prayer-timer.php
+++ b/shortcodes/prayer-timer.php
@@ -234,8 +234,8 @@ function show_prayer_timer( $atts ) {
                 setInterval( function() {
                     let time = new Date().getTime() - 1000;
                     if ( time < end_of_time ) {
-                        $seconds = Math.floor( (( end_of_time - time ) / 1000) % 60 )
-                        $('#clock-sticky-remaining-time').text( Math.floor( (( end_of_time - time ) / 1000 /60) % 60 ) + ':' +  ( $seconds < 10 ? '0' + $seconds : $seconds ) )
+                        seconds = Math.floor( (( end_of_time - time ) / 1000) % 60 )
+                        jQuery('#clock-sticky-remaining-time').text( Math.floor( (( end_of_time - time ) / 1000 /60) % 60 ) + ':' +  ( seconds < 10 ? '0' + seconds : seconds ) )
                     }
                 }, 5000)
                 jQuery('.clock-sticky-play-icon').hide();

--- a/shortcodes/prayer-timer.php
+++ b/shortcodes/prayer-timer.php
@@ -234,7 +234,7 @@ function show_prayer_timer( $atts ) {
                 setInterval( function() {
                     let time = new Date().getTime() - 1000;
                     if ( time < end_of_time ) {
-                        seconds = Math.floor( (( end_of_time - time ) / 1000) % 60 )
+                        const seconds = Math.floor( (( end_of_time - time ) / 1000) % 60 )
                         jQuery('#clock-sticky-remaining-time').text( Math.floor( (( end_of_time - time ) / 1000 /60) % 60 ) + ':' +  ( seconds < 10 ? '0' + seconds : seconds ) )
                     }
                 }, 5000)


### PR DESCRIPTION
In our instance jQuery isn't available as $ variable and function that does the time decreasing fails every 5s.

Also removed the leading $ from seconds variable, since AFAIK it should be mostly used to differentiate jQuery object containing variable.