### PR TITLE
Fix post excerpt rendering in post list

### DIFF
--- a/porches/generic/site/post-list-body.php
+++ b/porches/generic/site/post-list-body.php
@@ -146,7 +146,12 @@ if ( empty( $list->posts ) ){
                                 <span class="date"><i class="lnr lnr-calendar-full"></i><?php echo esc_html( $formatter->format( strtotime( $date ) ) )  ?></span>
                             </div>
                             <p>
-                                <?php echo wp_kses_post( esc_html( $item->post_excerpt ) ) ?>
+                                 <?php
+                                    setup_postdata( $item );
+                                    $excerpt = get_the_excerpt( $item );
+                                    echo wp_kses_post( esc_html( $excerpt ) );
+                                    wp_reset_postdata();
+                                    ?>
                             </p>
                             <a href="<?php echo esc_url( $url ) ?>" class="btn btn-common btn-rm"><?php esc_html_e( 'Read', 'disciple-tools-prayer-campaigns' ); ?></a>
                         </div>


### PR DESCRIPTION
Replaces direct use of $item->post_excerpt with get_the_excerpt() for proper excerpt retrieval. Ensures correct post data setup and reset for each item.

requires an update to the `dt_excerpt_more` function in `dt-assets/functions/cleanup.php` so it doesn't throw a warning. (https://github.com/DiscipleTools/disciple-tools-theme/pull/2751)